### PR TITLE
Add base page ItemsPage

### DIFF
--- a/PocketClient.Desktop/Views/ArchivePage.xaml
+++ b/PocketClient.Desktop/Views/ArchivePage.xaml
@@ -1,20 +1,21 @@
-﻿<Page
+﻿<local:ItemsPage
     x:Class="PocketClient.Desktop.Views.ArchivePage"
+    x:TypeArguments="viewModels:ArchiveViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    xmlns:models="using:PocketClient.Core.Models"
+    xmlns:local="using:PocketClient.Desktop.Views"
     xmlns:uc="using:PocketClient.Desktop.UserControls"
-    xmlns:views="using:PocketClient.Desktop.Views"
+    xmlns:models="using:PocketClient.Core.Models"
+    xmlns:viewModels="using:PocketClient.Desktop.ViewModels"
     xmlns:behaviors="using:PocketClient.Desktop.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
         <DataTemplate x:Key="DetailsTemplate" x:DataType="models:PocketItem">
             <Grid>
-                <views:DetailPage SelectedItem="{x:Bind}" />
+                <local:DetailPage SelectedItem="{x:Bind}" />
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -26,4 +27,4 @@
                             x:Uid="PageTitle_Archives"
                             ViewStateChanged="OnViewStateChanged" />
     </Grid>
-</Page>
+</local:ItemsPage>

--- a/PocketClient.Desktop/Views/ArchivePage.xaml.cs
+++ b/PocketClient.Desktop/Views/ArchivePage.xaml.cs
@@ -6,33 +6,10 @@ using PocketClient.Desktop.ViewModels;
 
 namespace PocketClient.Desktop.Views;
 
-public sealed partial class ArchivePage : Page
+public sealed partial class ArchivePage : ItemsPage<ArchiveViewModel>
 {
-    public ArchiveViewModel ViewModel
+    public ArchivePage() : base()
     {
-        get;
-    }
-
-    public ArchivePage()
-    {
-        ViewModel = App.GetService<ArchiveViewModel>();
         InitializeComponent();
-    }
-
-    private void OnViewStateChanged(object sender, ListDetailsViewState e)
-    {
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.ShowListAndDetails = true;
-        }
-        else
-        {
-            ViewModel.ShowListAndDetails = false;
-        }
-
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.EnsureItemSelected();
-        }
     }
 }

--- a/PocketClient.Desktop/Views/ArticlesPage.xaml
+++ b/PocketClient.Desktop/Views/ArticlesPage.xaml
@@ -1,8 +1,6 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
-<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
-
-<Page
+<local:ItemsPage
     x:Class="PocketClient.Desktop.Views.ArticlesPage"
+    x:TypeArguments="viewModels:ArticlesViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:PocketClient.Desktop.Views"
@@ -10,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:uc="using:PocketClient.Desktop.UserControls"
     xmlns:models="using:PocketClient.Core.Models"
-    xmlns:views="using:PocketClient.Desktop.Views"
+    xmlns:viewModels="using:PocketClient.Desktop.ViewModels"
     xmlns:behaviors="using:PocketClient.Desktop.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
@@ -18,7 +16,7 @@
     <Page.Resources>
         <DataTemplate x:Key="DetailsTemplate" x:DataType="models:PocketItem">
             <Grid>
-                <views:DetailPage SelectedItem="{x:Bind}" />
+                <local:DetailPage SelectedItem="{x:Bind}" />
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -30,4 +28,4 @@
                             x:Uid="PageTitle_Articles"
                             ViewStateChanged="OnViewStateChanged" />
     </Grid>
-</Page>
+</local:ItemsPage>

--- a/PocketClient.Desktop/Views/ArticlesPage.xaml.cs
+++ b/PocketClient.Desktop/Views/ArticlesPage.xaml.cs
@@ -12,21 +12,11 @@ namespace PocketClient.Desktop.Views;
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.
 /// </summary>
-public sealed partial class ArticlesPage : Page
+public sealed partial class ArticlesPage : ItemsPage<ArticlesViewModel>
 {
-    public ArticlesViewModel ViewModel { get; }
 
-    public ArticlesPage()
+    public ArticlesPage() : base()
     {
-        ViewModel = App.GetService<ArticlesViewModel>();
         this.InitializeComponent();
-    }
-
-    private void OnViewStateChanged(object sender, ListDetailsViewState e)
-    {
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.EnsureItemSelected();
-        }
     }
 }

--- a/PocketClient.Desktop/Views/FavoritesPage.xaml
+++ b/PocketClient.Desktop/Views/FavoritesPage.xaml
@@ -1,8 +1,6 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
-<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
-
-<Page
+<local:ItemsPage
     x:Class="PocketClient.Desktop.Views.FavoritesPage"
+    x:TypeArguments="viewModels:FavoritesViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:PocketClient.Desktop.Views"
@@ -10,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:uc="using:PocketClient.Desktop.UserControls"
     xmlns:models="using:PocketClient.Core.Models"
-    xmlns:views="using:PocketClient.Desktop.Views"
+    xmlns:viewModels="using:PocketClient.Desktop.ViewModels"
     xmlns:behaviors="using:PocketClient.Desktop.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
@@ -18,7 +16,7 @@
     <Page.Resources>
         <DataTemplate x:Key="DetailsTemplate" x:DataType="models:PocketItem">
             <Grid>
-                <views:DetailPage SelectedItem="{x:Bind}" />
+                <local:DetailPage SelectedItem="{x:Bind}" />
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -30,4 +28,4 @@
                             x:Uid="PageTitle_Favorites"
                             ViewStateChanged="OnViewStateChanged" />
     </Grid>
-</Page>
+</local:ItemsPage>

--- a/PocketClient.Desktop/Views/FavoritesPage.xaml.cs
+++ b/PocketClient.Desktop/Views/FavoritesPage.xaml.cs
@@ -12,30 +12,10 @@ namespace PocketClient.Desktop.Views;
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.
 /// </summary>
-public sealed partial class FavoritesPage : Page
+public sealed partial class FavoritesPage : ItemsPage<FavoritesViewModel>
 {
-    public FavoritesViewModel ViewModel { get; }
-
-    public FavoritesPage()
+    public FavoritesPage() : base()
     {
-        ViewModel = App.GetService<FavoritesViewModel>();
         this.InitializeComponent();
-    }
-
-    private void OnViewStateChanged(object sender, ListDetailsViewState e)
-    {
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.ShowListAndDetails = true;
-        }
-        else
-        {
-            ViewModel.ShowListAndDetails = false;
-        }
-
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.EnsureItemSelected();
-        }
     }
 }

--- a/PocketClient.Desktop/Views/ItemsPage.cs
+++ b/PocketClient.Desktop/Views/ItemsPage.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.Versioning;
+using CommunityToolkit.WinUI.UI.Controls;
+using Microsoft.UI.Xaml.Controls;
+using PocketClient.Desktop.ViewModels;
+
+namespace PocketClient.Desktop.Views;
+
+public class ItemsPage<T> : Page where T : ItemsViewModel
+{
+    public readonly T ViewModel;
+
+    public ItemsPage()
+    {
+        ViewModel = App.GetService<T>();
+    }
+
+    protected void OnViewStateChanged(object sender, ListDetailsViewState e)
+    {
+        if (e == ListDetailsViewState.Both)
+        {
+            ViewModel.ShowListAndDetails = true;
+        }
+        else
+        {
+            ViewModel.ShowListAndDetails = false;
+        }
+
+        if (e == ListDetailsViewState.Both)
+        {
+            ViewModel.EnsureItemSelected();
+        }
+    }
+}

--- a/PocketClient.Desktop/Views/MyListPage.xaml
+++ b/PocketClient.Desktop/Views/MyListPage.xaml
@@ -1,20 +1,22 @@
-﻿<Page
+﻿<local:ItemsPage
     x:Class="PocketClient.Desktop.Views.MyListPage"
+    x:TypeArguments="viewModels:MyListViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:local="using:PocketClient.Desktop.Views"
     xmlns:models="using:PocketClient.Core.Models"
     xmlns:uc="using:PocketClient.Desktop.UserControls"
-    xmlns:views="using:PocketClient.Desktop.Views"
+    xmlns:viewModels="using:PocketClient.Desktop.ViewModels"
     xmlns:behaviors="using:PocketClient.Desktop.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
         <DataTemplate x:Key="DetailsTemplate" x:DataType="models:PocketItem">
             <Grid>
-                <views:DetailPage SelectedItem="{x:Bind}" />
+                <local:DetailPage SelectedItem="{x:Bind}" />
             </Grid>
         </DataTemplate>
     </Page.Resources> 
@@ -27,4 +29,4 @@
                             ViewStateChanged="OnViewStateChanged">
         </uc:ItemListControl>
     </Grid>
-</Page>
+</local:ItemsPage>

--- a/PocketClient.Desktop/Views/MyListPage.xaml.cs
+++ b/PocketClient.Desktop/Views/MyListPage.xaml.cs
@@ -1,38 +1,13 @@
 ﻿using CommunityToolkit.WinUI.UI.Controls;
 
-using Microsoft.UI.Xaml.Controls;
-
 using PocketClient.Desktop.ViewModels;
 
 namespace PocketClient.Desktop.Views;
 
-public sealed partial class MyListPage : Page
+public sealed partial class MyListPage : ItemsPage<MyListViewModel>
 {
-    public MyListViewModel ViewModel
+    public MyListPage() : base()
     {
-        get;
-    }
-
-    public MyListPage()
-    {
-        ViewModel = App.GetService<MyListViewModel>();
         InitializeComponent();
-    }
-
-    private void OnViewStateChanged(object sender, ListDetailsViewState e)
-    {
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.ShowListAndDetails = true;
-        } 
-        else
-        {
-            ViewModel.ShowListAndDetails = false;
-        }
-        
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.EnsureItemSelected();
-        }
     }
 }

--- a/PocketClient.Desktop/Views/SearchResultsPage.xaml
+++ b/PocketClient.Desktop/Views/SearchResultsPage.xaml
@@ -1,20 +1,22 @@
-<Page
+<local:ItemsPage
     x:Class="PocketClient.Desktop.Views.SearchResultsPage"
+    x:TypeArguments="viewModels:SearchResultsViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:local="using:PocketClient.Desktop.Views"
     xmlns:models="using:PocketClient.Core.Models"
     xmlns:uc="using:PocketClient.Desktop.UserControls"
-    xmlns:views="using:PocketClient.Desktop.Views"
+    xmlns:viewModels="using:PocketClient.Desktop.ViewModels"
     xmlns:behaviors="using:PocketClient.Desktop.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
         <DataTemplate x:Key="DetailsTemplate" x:DataType="models:PocketItem">
             <Grid>
-                <views:DetailPage SelectedItem="{x:Bind}" />
+                <local:DetailPage SelectedItem="{x:Bind}" />
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -27,4 +29,4 @@
                             ViewStateChanged="OnViewStateChanged">
         </uc:ItemListControl>
     </Grid>
-</Page>
+</local:ItemsPage>

--- a/PocketClient.Desktop/Views/SearchResultsPage.xaml.cs
+++ b/PocketClient.Desktop/Views/SearchResultsPage.xaml.cs
@@ -6,24 +6,10 @@ using PocketClient.Desktop.ViewModels;
 
 namespace PocketClient.Desktop.Views;
 
-public sealed partial class SearchResultsPage : Page
+public sealed partial class SearchResultsPage : ItemsPage<SearchResultsViewModel>
 {
-    public SearchResultsViewModel ViewModel
-    {
-        get;
-    }
-
-    public SearchResultsPage()
-    {
-        ViewModel = App.GetService<SearchResultsViewModel>();
-        InitializeComponent();
-    }
-
-    private void OnViewStateChanged(object sender, ListDetailsViewState e)
-    {
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.EnsureItemSelected();
-        }
+    public SearchResultsPage() : base() 
+    { 
+        InitializeComponent(); 
     }
 }

--- a/PocketClient.Desktop/Views/TaggedItemsPage.xaml
+++ b/PocketClient.Desktop/Views/TaggedItemsPage.xaml
@@ -1,20 +1,21 @@
-<Page
+<local:ItemsPage
     x:Class="PocketClient.Desktop.Views.TaggedItemsPage"
+    x:TypeArguments="viewModels:TaggedItemsViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:local="using:PocketClient.Desktop.Views"
     xmlns:models="using:PocketClient.Core.Models"
     xmlns:uc="using:PocketClient.Desktop.UserControls"
-    xmlns:views="using:PocketClient.Desktop.Views"
+    xmlns:viewModels="using:PocketClient.Desktop.ViewModels"
     xmlns:behaviors="using:PocketClient.Desktop.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
         <DataTemplate x:Key="DetailsTemplate" x:DataType="models:PocketItem">
             <Grid>
-                <views:DetailPage SelectedItem="{x:Bind}" />
+                <local:DetailPage SelectedItem="{x:Bind}" />
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -27,4 +28,4 @@
                             ViewStateChanged="OnViewStateChanged">
         </uc:ItemListControl>
     </Grid>
-</Page>
+</local:ItemsPage>

--- a/PocketClient.Desktop/Views/TaggedItemsPage.xaml.cs
+++ b/PocketClient.Desktop/Views/TaggedItemsPage.xaml.cs
@@ -13,24 +13,10 @@ namespace PocketClient.Desktop.Views;
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.
 /// </summary>
-public sealed partial class TaggedItemsPage : Page
+public sealed partial class TaggedItemsPage : ItemsPage<TaggedItemsViewModel>
 {
-    public TaggedItemsViewModel ViewModel
+    public TaggedItemsPage(): base()
     {
-        get;
-    }
-
-    public TaggedItemsPage()
-    {
-        ViewModel = App.GetService<TaggedItemsViewModel>();
         this.InitializeComponent();
-    }
-
-    private void OnViewStateChanged(object sender, ListDetailsViewState e)
-    {
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.EnsureItemSelected();
-        }
     }
 }

--- a/PocketClient.Desktop/Views/VideosPage.xaml
+++ b/PocketClient.Desktop/Views/VideosPage.xaml
@@ -1,8 +1,6 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
-<!-- Licensed under the MIT License. See LICENSE in the project root for license information. -->
-
-<Page
+<local:ItemsPage
     x:Class="PocketClient.Desktop.Views.VideosPage"
+    x:TypeArguments="viewModels:VideosViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:PocketClient.Desktop.Views"
@@ -10,14 +8,14 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:uc="using:PocketClient.Desktop.UserControls"
     xmlns:models="using:PocketClient.Core.Models"
-    xmlns:views="using:PocketClient.Desktop.Views"
+    xmlns:viewModels="using:PocketClient.Desktop.ViewModels"
     xmlns:behaviors="using:PocketClient.Desktop.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
         <DataTemplate x:Key="DetailsTemplate" x:DataType="models:PocketItem">
             <Grid>
-                <views:DetailPage SelectedItem="{x:Bind}" />
+                <local:DetailPage SelectedItem="{x:Bind}" />
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -29,4 +27,4 @@
                             x:Uid="PageTitle_Videos"
                             ViewStateChanged="OnViewStateChanged" />
     </Grid>
-</Page>
+</local:ItemsPage>

--- a/PocketClient.Desktop/Views/VideosPage.xaml.cs
+++ b/PocketClient.Desktop/Views/VideosPage.xaml.cs
@@ -12,24 +12,10 @@ namespace PocketClient.Desktop.Views;
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.
 /// </summary>
-public sealed partial class VideosPage : Page
+public sealed partial class VideosPage : ItemsPage<VideosViewModel>
 {
-    public VideosViewModel ViewModel
+    public VideosPage() : base()
     {
-        get;
-    }
-
-    public VideosPage()
-    {
-        ViewModel = App.GetService<VideosViewModel>();
         this.InitializeComponent();
-    }
-
-    private void OnViewStateChanged(object sender, ListDetailsViewState e)
-    {
-        if (e == ListDetailsViewState.Both)
-        {
-            ViewModel.EnsureItemSelected();
-        }
     }
 }


### PR DESCRIPTION
It tries to add a base class for all item list pages to simplify the code.
Please notice that, right now, this is a draft PR, it won't work as expected, because WinUI3 doesn't support XAML 2009 schema yet. See [Proposal: Support the XAML 2009 Schema](https://github.com/microsoft/microsoft-ui-xaml/issues/7037)